### PR TITLE
画面のちらつき対応

### DIFF
--- a/app/routes/_auth.login.tsx
+++ b/app/routes/_auth.login.tsx
@@ -1,6 +1,8 @@
 import { LoginTemplate } from "@/components/templates/LoginTemplate";
 import type { LoaderFunctionArgs } from "react-router-dom";
 import { requireNoAuthentication } from "@/features/auth/utils/require-no-auth";
+import { Suspense } from "react";
+import { Loading } from "@/components/atoms/loadings";
 
 // 既にログイン済みの場合、/top にリダイレクト
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -9,9 +11,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 export default function Login() {
   return (
-    <LoginTemplate
-      title="ログイン"
-      subtitle="メールアドレスとパスワードを入力してください"
-    />
+    <Suspense fallback={<Loading />}>
+      <LoginTemplate
+        title="ログイン"
+        subtitle="メールアドレスとパスワードを入力してください"
+      />
+    </Suspense>
   );
 }

--- a/app/routes/_protected.top.tsx
+++ b/app/routes/_protected.top.tsx
@@ -6,6 +6,8 @@ import { Button } from "@/components/atoms/links-and-buttons/Button";
 import { Loading } from "@/components/atoms/loadings";
 import { ErrorMessage } from "@/components/atoms/ErrorMessage";
 import { useUsersQuery } from "@/features/users/hooks/queries/useUsers";
+import { useNavigation } from "react-router-dom";
+import { Suspense } from "react";
 
 /**
  * NOTE: ユーザーデータの取得と管理について
@@ -95,56 +97,63 @@ import { useUsersQuery } from "@/features/users/hooks/queries/useUsers";
 export default function ProtectedTopPage() {
   const { user: currentUser } = authStore();
   const { logout } = useAuth();
+  const navigation = useNavigation();
 
   const { data: users = [], isLoading, error } = useUsersQuery();
 
-  if (isLoading) return <Loading />;
+  const isNavigating = navigation.state === "loading";
+
+  if (isLoading || isNavigating) {
+    return <Loading />;
+  }
 
   if (error)
     return <ErrorMessage message="ユーザーデータの取得に失敗しました" />;
 
   return (
-    <Card width="w-full max-w-md mx-auto" padding="p-8" className="shadow-md">
-      <div className="text-center">
-        <Heading level="h2" className="mb-4">
-          認証済みページ
-        </Heading>
-        <Text variant="default" className="mb-6">
-          このページは認証状態でのみ表示可能です
-        </Text>
-      </div>
-
-      <div className="border-t border-gray-200 pt-4">
-        <Heading level="h3" className="mb-2">
-          ユーザー情報
-        </Heading>
-        <div className="space-y-2">
-          <Text as="p">
-            <span className="font-medium">名前：</span> {currentUser?.name}
-          </Text>
-          <Text as="p">
-            <span className="font-medium">メール：</span> {currentUser?.email}
+    <Suspense fallback={<Loading />}>
+      <Card width="w-full max-w-md mx-auto" padding="p-8" className="shadow-md">
+        <div className="text-center">
+          <Heading level="h2" className="mb-4">
+            認証済みページ
+          </Heading>
+          <Text variant="default" className="mb-6">
+            このページは認証状態でのみ表示可能です
           </Text>
         </div>
-      </div>
 
-      <div className="mt-6 text-center">
-        <Button variant="destructive" onClick={logout}>
-          ログアウト
-        </Button>
-      </div>
+        <div className="border-t border-gray-200 pt-4">
+          <Heading level="h3" className="mb-2">
+            ユーザー情報
+          </Heading>
+          <div className="space-y-2">
+            <Text as="p">
+              <span className="font-medium">名前：</span> {currentUser?.name}
+            </Text>
+            <Text as="p">
+              <span className="font-medium">メール：</span> {currentUser?.email}
+            </Text>
+          </div>
+        </div>
 
-      <div className="mt-6">
-        <h1>ユーザー一覧</h1>
-        <ul className="user-list">
-          {users.map((user) => (
-            <li key={user.id} className="user-list-item">
-              <span className="user-name">{user.name}</span>
-              <span className="user-email">({user.email})</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </Card>
+        <div className="mt-6 text-center">
+          <Button variant="destructive" onClick={logout}>
+            ログアウト
+          </Button>
+        </div>
+
+        <div className="mt-6">
+          <h1>ユーザー一覧</h1>
+          <ul className="user-list">
+            {users.map((user) => (
+              <li key={user.id} className="user-list-item">
+                <span className="user-name">{user.name}</span>
+                <span className="user-email">({user.email})</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Card>
+    </Suspense>
   );
 }

--- a/src/features/auth/hooks/queries/useLoginMutation.ts
+++ b/src/features/auth/hooks/queries/useLoginMutation.ts
@@ -21,14 +21,12 @@ export const useLoginMutation = () => {
       clearError();
       return await login(email, password);
     },
-    onSuccess: (user) => {
+    onSuccess: async (user) => {
       setUser(user);
       setIsAuthenticated(true);
 
-      // 少し遅延させてから遷移させることで、状態更新が完了してからの遷移を保証
-      setTimeout(() => {
-        navigate(PATHS.PROTECTED.TOP);
-      }, 100);
+      await Promise.resolve();
+      navigate(PATHS.PROTECTED.TOP);
     },
     onError: (error) => {
       handleError(error, "ログイン");


### PR DESCRIPTION
# 対応内容
/login から /top への遷移時に発生していた画面のちらつきに対応

1. 非同期処理の最適化
- `useLoginMutation`の`onSuccess`ハンドラーで、状態更新（`setUser`と`setIsAuthenticated`）の完了を`Promise.resolve()`で待ってから画面遷移を行うように修正
- これにより、状態更新と画面遷移のタイミングの不一致によるちらつきを防止

2. Suspenseによるローディング表示の改善
- ログインページとトップページの両方で`Suspense`を使用
- ローディング中は`Loading`コンポーネントを表示